### PR TITLE
Add multiple different config filenames

### DIFF
--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -26,10 +26,10 @@ def check_suite_event():
 class TestSuite:
 
     @pytest.fixture()
-    def handler(self):
+    def handler(self, sns):
         hnd = CheckSuite()
         subject, message = check_suite_event()
-        notice = sns()
+        notice = dict(sns)
         notice['Records'][0]['Sns']['Subject'] = subject
         notice['Records'][0]['Sns']['Message'] = message
         hnd.event = notice


### PR DESCRIPTION
You can now put the config file inside the .github folder,
you can name it fussyfox.yml instead of checks. It is not
case sensitive, will allow JSON files and different extention
names.