### PR TITLE
Fix name of config file for link in getting started document.

### DIFF
--- a/suite.py
+++ b/suite.py
@@ -22,6 +22,7 @@ class CheckSuite(DownloadCodeMixin, GitHubEvent):
     REQUESTED = 'requested'
     REREQUESTED = 'rerequested'
 
+    config_file_default = '.fussyfox.yml'
     config_file_pattern = re.compile(
         r'(.github/)?\.?(checks|fussyfox)\.(yml|yaml|json)',
         re.IGNORECASE,
@@ -138,7 +139,7 @@ class CheckSuite(DownloadCodeMixin, GitHubEvent):
         with open('template.yml') as f:
             template = f.read()
         kwargs = {
-            'filename': self.config_file_pattern,
+            'filename': self.config_file_default,
             'value': template
         }
         return url + urllib.parse.urlencode(kwargs)

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -82,6 +82,7 @@ class TestSuite:
 
         assert "[click here][template]" in body
         assert "*   [example](https://example.com/)" in body
+        assert "https://github.com/baxterthehacker/public-repo/new/master?filename=.fussyfox.yml" in body
 
     def test_call(self, handler):
         handler.create_check_run = lambda *args, **kwargs: None


### PR DESCRIPTION
I stumbled over this in https://github.com/jazzband/python-geojson/pull/123/checks?check_run_id=108705174 The link looks like this there: https://github.com/jazzband/python-geojson/new/master?filename=re.compile%28%27%28.github%2F%29%3F%5C%5C.%3F%28checks%7Cfussyfox%29%5C%5C.%28yml%7Cyaml%7Cjson%29%27%2C+re.IGNORECASE%29&value=%23%23+list+of+checks+you+would+like+to+run+on+this+repository%0A%23+e.g.%3A%0A-+bandit%0A-+flake8%0A-+isort%0A 